### PR TITLE
feat(api): send confirmation email on transaction creation

### DIFF
--- a/apps/api/src/routes/transaction.ts
+++ b/apps/api/src/routes/transaction.ts
@@ -3,6 +3,7 @@ import { AppDataSource } from '../index';
 import { Transaction } from '../entities/Transaction';
 import { Quote } from '../entities/Quote';
 import { z } from 'zod';
+import { sendTradeInEmail } from '../utils/email';
 
 const router = Router();
 
@@ -47,6 +48,18 @@ router.post('/', async (req, res) => {
     });
 
     const savedTransaction = await transactionRepository.save(transaction);
+
+    // Send confirmation email to the customer
+    try {
+      await sendTradeInEmail(
+        validatedData.customerInfo.email,
+        savedTransaction.id,
+        validatedData.customerInfo.name
+      );
+    } catch (emailError) {
+      console.error('Error sending confirmation email:', emailError);
+    }
+
     res.status(201).json({ data: savedTransaction });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/apps/api/src/utils/email.ts
+++ b/apps/api/src/utils/email.ts
@@ -1,0 +1,30 @@
+export async function sendTradeInEmail(
+  to: string,
+  tradeInId: string,
+  name: string
+): Promise<void> {
+  const apiUrl = process.env.EMAIL_API_URL;
+  const apiKey = process.env.EMAIL_API_KEY;
+  const from = process.env.EMAIL_FROM;
+
+  const subject = 'Trade-in Confirmation';
+  const text = `Hi ${name},\n\nThank you for trusting us with your device. Your trade-in ID is ${tradeInId}.\n\nBest regards,\nTrade-In Team`;
+
+  if (!apiUrl || !apiKey || !from) {
+    console.log(`Email not configured. Would send to ${to}: ${subject} - ${text}`);
+    return;
+  }
+
+  try {
+    await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ to, from, subject, text }),
+    });
+  } catch (error) {
+    console.error('Failed to send trade-in confirmation email:', error);
+  }
+}


### PR DESCRIPTION
## Summary
- send thank-you email with trade-in ID after transactions are created
- add utility helper to dispatch confirmation emails through configured HTTP service

## Testing
- `pnpm lint` (fails: No files matching the pattern "src/" were found.)
- `pnpm test` (fails: No tests found, exiting with code 1)

------
https://chatgpt.com/codex/tasks/task_e_6894a955a39883288880445215f4b468